### PR TITLE
Con2 268 bookings statuses

### DIFF
--- a/backend/src/modules/booking/booking.service.ts
+++ b/backend/src/modules/booking/booking.service.ts
@@ -39,7 +39,6 @@ import { handleSupabaseError } from "@src/utils/handleError.utils";
 import { BookingPreview } from "@common/bookings/booking.types";
 import { BookingItemsService } from "../booking_items/booking-items.service";
 import { StorageItemRow } from "../storage-items/interfaces/storage-item.interface";
-import { BookingWithOrgStatus } from "./types/booking.interface";
 
 dayjs.extend(utc);
 @Injectable()
@@ -77,26 +76,7 @@ export class BookingService {
     searchquery?: string,
     status_filter?: string,
   ): Promise<ApiResponse<BookingPreview>> {
-    const { from, to } = getPaginationRange(page, limit);
-
-    const query = supabase
-      .from("view_bookings_with_user_info")
-      .select("*", { count: "exact" })
-      .range(from, to)
-      .order(order_by ?? "booking_number", { ascending: ascending });
-
-    if (status_filter) query.eq("status", status_filter);
-
-    // Match any field if there is a searchquery
-    if (searchquery) {
-      query.or(
-        `booking_number.ilike.%${searchquery}%,` +
-          `full_name.ilike.%${searchquery}%,` +
-          `created_at_text.ilike.%${searchquery}%`,
-      );
-    }
-
-    // Filter bookings by organization ID
+    // First, get all bookings that have items from the specified organization
     const itemsRes = await supabase
       .from("booking_items")
       .select("booking_id")
@@ -108,32 +88,56 @@ export class BookingService {
         ((itemsRes.data || []) as BookingItemRow[]).map((r) => r.booking_id),
       ),
     );
-    if (bookingIds.length > 0) {
-      query.in("id", bookingIds);
-    } else {
-      // Force empty results if no matching bookings
-      query.eq("id", "00000000-0000-0000-0000-000000000000");
+
+    if (bookingIds.length === 0) {
+      return {
+        data: [],
+        count: 0,
+        error: null,
+        status: 200,
+        statusText: "OK",
+        metadata: getPaginationMeta(0, page, limit),
+      };
     }
 
-    const result = await query;
+    // Get all bookings from the organization and calculate their org-specific status
+    const allBookingsQuery = supabase
+      .from("view_bookings_with_user_info")
+      .select("*")
+      .in("id", bookingIds);
 
-    // Attach derived organization status for each booking indicating whether all items for this org are confirmed
-    if (result.data && result.data.length > 0) {
-      const bookingIds = result.data
+    if (searchquery) {
+      allBookingsQuery.or(
+        `booking_number.ilike.%${searchquery}%,` +
+          `full_name.ilike.%${searchquery}%,` +
+          `created_at_text.ilike.%${searchquery}%`,
+      );
+    }
+
+    const allBookingsResult = await allBookingsQuery;
+    if (allBookingsResult.error) handleSupabaseError(allBookingsResult.error);
+
+    let bookingsWithOrgStatus: (BookingPreview & {
+      org_status_for_active_org?: string;
+    })[] = [];
+
+    // Calculate org-specific status for each booking
+    if (allBookingsResult.data && allBookingsResult.data.length > 0) {
+      const availableBookingIds = allBookingsResult.data
         .map((b) => b.id)
         .filter(Boolean) as string[];
 
-      if (bookingIds.length > 0) {
-        const itemsRes = await supabase
+      if (availableBookingIds.length > 0) {
+        const orgItemsRes = await supabase
           .from("booking_items")
           .select("booking_id,status")
-          .in("booking_id", bookingIds)
+          .in("booking_id", availableBookingIds)
           .eq("provider_organization_id", org_id);
-        if (itemsRes.error) handleSupabaseError(itemsRes.error);
+        if (orgItemsRes.error) handleSupabaseError(orgItemsRes.error);
 
         // Map booking_id to array of statuses for this org
         const statusMap = new Map<string, string[]>();
-        (itemsRes.data || []).forEach((row) => {
+        (orgItemsRes.data || []).forEach((row) => {
           const r = row as { booking_id: string; status: string };
           const arr = statusMap.get(r.booking_id) || [];
           arr.push(r.status);
@@ -141,20 +145,54 @@ export class BookingService {
         });
 
         // Attach org_status_for_active_org to each booking row
-        (result.data as BookingPreview[]).forEach((b) => {
+        bookingsWithOrgStatus = (
+          allBookingsResult.data as BookingPreview[]
+        ).map((b) => {
           const bid = b.id;
           const statuses = statusMap.get(bid) || [];
-          (b as BookingWithOrgStatus).org_status_for_active_org =
-            deriveOrgStatus(statuses);
+          const orgStatus = deriveOrgStatus(statuses);
+          return {
+            ...b,
+            org_status_for_active_org: orgStatus,
+          };
         });
       }
     }
-    const { error, count } = result;
-    if (error) handleSupabaseError(error);
 
-    const metadata = getPaginationMeta(count, page, limit);
+    // Apply status filter based on org-specific status
+    if (status_filter) {
+      bookingsWithOrgStatus = bookingsWithOrgStatus.filter(
+        (booking) => booking.org_status_for_active_org === status_filter,
+      );
+    }
+
+    // Sort the filtered results
+    bookingsWithOrgStatus.sort((a, b) => {
+      const aValue = a[order_by as keyof typeof a];
+      const bValue = b[order_by as keyof typeof b];
+
+      // Handle undefined values
+      if (aValue === undefined && bValue === undefined) return 0;
+      if (aValue === undefined) return ascending ? 1 : -1;
+      if (bValue === undefined) return ascending ? -1 : 1;
+
+      if (aValue < bValue) return ascending ? -1 : 1;
+      if (aValue > bValue) return ascending ? 1 : -1;
+      return 0;
+    });
+
+    // Apply pagination
+    const totalCount = bookingsWithOrgStatus.length;
+    const { from, to } = getPaginationRange(page, limit);
+    const paginatedData = bookingsWithOrgStatus.slice(from, to + 1);
+
+    const metadata = getPaginationMeta(totalCount, page, limit);
     return {
-      ...result,
+      data: paginatedData,
+      count: totalCount,
+      error: null,
+      status: 200,
+      statusText: "OK",
       metadata,
     };
   }

--- a/backend/src/modules/booking/types/booking.interface.ts
+++ b/backend/src/modules/booking/types/booking.interface.ts
@@ -74,7 +74,8 @@ export type ValidBookingOrder =
   | "booking_number"
   | "status"
   | "final_amount"
-  | "full_name";
+  | "full_name"
+  | "start_date";
 
 export type BookingWithOrgStatus = BookingPreview & {
   org_status_for_active_org: BookingStatus;

--- a/common/bookings/booking.types.ts
+++ b/common/bookings/booking.types.ts
@@ -1,4 +1,4 @@
-import { Database } from "../supabase.types"
+import { Database } from "../supabase.types";
 import { StripNull } from "../helper.types";
 
 export type BookingUserView =
@@ -6,6 +6,12 @@ export type BookingUserView =
 export type BookingUserViewRow = BookingUserView["Row"];
 
 export type BookingPreview = StripNull<BookingUserViewRow>;
+
+/* Extended BookingPreview with additional org-specific fields from backend */
+export type BookingPreviewWithOrgData = BookingPreview & {
+  org_status_for_active_org?: string;
+  start_date?: string;
+};
 
 export type BookingTable = Database["public"]["Tables"]["bookings"];
 export type Booking = Database["public"]["Tables"]["bookings"]["Row"];

--- a/frontend/src/pages/AdminPanel/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminPanel/AdminDashboard.tsx
@@ -114,7 +114,13 @@ const AdminDashboard = () => {
     {
       accessorKey: "status",
       header: t.bookingList.columns.status[lang],
-      cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      cell: ({ row }) => {
+        const orgStatus = row.original as BookingPreview & {
+          org_status_for_active_org?: string;
+        };
+        const status = orgStatus.org_status_for_active_org ?? orgStatus.status;
+        return <StatusBadge status={status} />;
+      },
     },
     {
       accessorKey: "created_at",

--- a/frontend/src/pages/AdminPanel/BookingList.tsx
+++ b/frontend/src/pages/AdminPanel/BookingList.tsx
@@ -33,7 +33,6 @@ const BookingList = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<BookingStatus>("all");
   const [orderBy, setOrderBy] = useState<ValidBookingOrder>("created_at");
-  // For start_date: ascending=true (closest dates first), for created_at: ascending=false (most recent first)
   const getAscending = (order: ValidBookingOrder) => order === "start_date";
   const { totalPages, page } = useAppSelector(selectBookingPagination);
   const { lang } = useLanguage();

--- a/frontend/src/pages/AdminPanel/BookingList.tsx
+++ b/frontend/src/pages/AdminPanel/BookingList.tsx
@@ -114,7 +114,6 @@ const BookingList = () => {
       header: t.bookingList.columns.status[lang],
       enableSorting: false,
       cell: ({ row }) => {
-        // backend attaches org_status_for_active_org; prefer that when present
         const maybe = row.original as BookingPreview & {
           org_status_for_active_org?: string;
         };
@@ -204,6 +203,15 @@ const BookingList = () => {
               </option>
               <option value="cancelled">
                 {t.bookingList.filters.status.cancelled[lang]}
+              </option>
+              <option value="picked_up">
+                {t.bookingList.filters.status.picked_up[lang]}
+              </option>
+              <option value="returned">
+                {t.bookingList.filters.status.returned[lang]}
+              </option>
+              <option value="completed">
+                {t.bookingList.filters.status.completed[lang]}
               </option>
             </select>
             {(searchQuery || statusFilter !== "all") && (

--- a/frontend/src/pages/AdminPanel/BookingList.tsx
+++ b/frontend/src/pages/AdminPanel/BookingList.tsx
@@ -7,18 +7,18 @@ import {
   getOrderedBookings,
   selectBookingPagination,
 } from "@/store/slices/bookingsSlice";
-import { Eye, LoaderCircle } from "lucide-react";
+import { Eye, LoaderCircle, Calendar, Clock } from "lucide-react";
 import { PaginatedDataTable } from "@/components/ui/data-table-paginated";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
-import { BookingStatus } from "@/types";
+import { BookingStatus, ValidBookingOrder } from "@/types";
 import { useLanguage } from "@/context/LanguageContext";
 import { t } from "@/translations";
 import { useFormattedDate } from "@/hooks/useFormattedDate";
 import { useAuth } from "@/hooks/useAuth";
 import { StatusBadge } from "@/components/StatusBadge";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { BookingPreview } from "@common/bookings/booking.types";
+import { BookingPreviewWithOrgData } from "@common/bookings/booking.types";
 import { selectActiveOrganizationId } from "@/store/slices/rolesSlice";
 import { useNavigate } from "react-router-dom";
 import { formatBookingStatus } from "@/utils/format";
@@ -32,8 +32,9 @@ const BookingList = () => {
   const { authLoading } = useAuth();
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<BookingStatus>("all");
-  const ORDER_BY = "created_at" as const;
-  const ASCENDING = false;
+  const [orderBy, setOrderBy] = useState<ValidBookingOrder>("created_at");
+  // For start_date: ascending=true (closest dates first), for created_at: ascending=false (most recent first)
+  const getAscending = (order: ValidBookingOrder) => order === "start_date";
   const { totalPages, page } = useAppSelector(selectBookingPagination);
   const { lang } = useLanguage();
   const { formatDate } = useFormattedDate();
@@ -49,12 +50,19 @@ const BookingList = () => {
     setSearchQuery(e.target.value);
   };
 
+  const handleOrderToggle = (newOrderBy: ValidBookingOrder) => {
+    if (newOrderBy !== orderBy) {
+      setOrderBy(newOrderBy);
+      setCurrentPage(1);
+    }
+  };
+
   /*----------------------side-effects----------------------------------*/
   useEffect(() => {
     void dispatch(
       getOrderedBookings({
-        ordered_by: ORDER_BY,
-        ascending: ASCENDING,
+        ordered_by: orderBy,
+        ascending: getAscending(orderBy),
         page: currentPage,
         limit: 10,
         searchquery: debouncedSearchQuery,
@@ -65,14 +73,13 @@ const BookingList = () => {
     debouncedSearchQuery,
     statusFilter,
     page,
-    ORDER_BY,
+    orderBy,
     dispatch,
     currentPage,
-    ASCENDING,
     activeOrgId,
   ]);
 
-  const columns: ColumnDef<BookingPreview>[] = [
+  const columns: ColumnDef<BookingPreviewWithOrgData>[] = [
     {
       id: "actions",
       size: 5,
@@ -110,16 +117,23 @@ const BookingList = () => {
       ),
     },
     {
+      accessorKey: "start_date",
+      header: t.bookingList.columns.startDate[lang],
+      enableSorting: true,
+      cell: ({ row }) => {
+        const startDate = row.original.start_date;
+        if (!startDate) return t.bookingList.status.unknown[lang];
+        return formatDate(new Date(startDate), "d MMM yyyy");
+      },
+    },
+    {
       id: "org_status",
       header: t.bookingList.columns.status[lang],
       enableSorting: false,
       cell: ({ row }) => {
-        const maybe = row.original as BookingPreview & {
-          org_status_for_active_org?: string;
-        };
         const status =
-          maybe.org_status_for_active_org ??
-          (maybe.status as string | undefined);
+          row.original.org_status_for_active_org ??
+          (row.original.status as string | undefined);
         return (
           <StatusBadge
             status={formatBookingStatus(status as BookingStatus) ?? "unknown"}
@@ -158,8 +172,8 @@ const BookingList = () => {
             onClick={() =>
               dispatch(
                 getOrderedBookings({
-                  ordered_by: ORDER_BY,
-                  ascending: ASCENDING,
+                  ordered_by: orderBy,
+                  ascending: getAscending(orderBy),
                   page: currentPage,
                   limit: 10,
                   searchquery: debouncedSearchQuery,
@@ -226,6 +240,41 @@ const BookingList = () => {
                 {t.bookingList.filters.clear[lang]}
               </Button>
             )}
+          </div>
+
+          {/* Ordering Toggle Buttons */}
+          <div className="flex gap-2 items-center">
+            <span className="text-sm italic text-primary/70">
+              {t.bookingList.filters.filterBy[lang]}
+            </span>
+            <Button
+              onClick={() => handleOrderToggle("created_at")}
+              variant={orderBy === "created_at" ? "secondary" : "default"}
+              size="sm"
+              disabled={orderBy === "created_at"}
+              className={`flex items-center gap-2 ${
+                orderBy === "created_at"
+                  ? "cursor-not-allowed opacity-75"
+                  : "cursor-pointer"
+              }`}
+            >
+              <Clock className="h-4 w-4" />
+              {t.bookingList.filters.recent[lang]}
+            </Button>
+            <Button
+              onClick={() => handleOrderToggle("start_date")}
+              variant={orderBy === "start_date" ? "secondary" : "default"}
+              size="sm"
+              disabled={orderBy === "start_date"}
+              className={`flex items-center gap-2 ${
+                orderBy === "start_date"
+                  ? "cursor-not-allowed opacity-75"
+                  : "cursor-pointer"
+              }`}
+            >
+              <Calendar className="h-4 w-4" />
+              {t.bookingList.filters.upcoming[lang]}
+            </Button>
           </div>
         </div>
         {/* Table of Bookings */}

--- a/frontend/src/translations/modules/bookingList.ts
+++ b/frontend/src/translations/modules/bookingList.ts
@@ -27,10 +27,6 @@ export const bookingList = {
         fi: "Peruutettu",
         en: "Cancelled",
       },
-      cancelledByAdmin: {
-        fi: "Ylläpitäjän peruuttama",
-        en: "Cancelled by admin",
-      },
       rejected: {
         fi: "Hylätty",
         en: "Rejected",
@@ -42,6 +38,14 @@ export const bookingList = {
       deleted: {
         fi: "Poistettu",
         en: "Deleted",
+      },
+      returned: {
+        fi: "Palautettu",
+        en: "Returned",
+      },
+      picked_up: {
+        fi: "Noudettu",
+        en: "Picked Up",
       },
     },
     clear: {

--- a/frontend/src/translations/modules/bookingList.ts
+++ b/frontend/src/translations/modules/bookingList.ts
@@ -52,6 +52,18 @@ export const bookingList = {
       fi: "Tyhjennä suodattimet",
       en: "Clear Filters",
     },
+    filterBy: {
+      fi: "Suodata",
+      en: "Filter by",
+    },
+    recent: {
+      fi: "Viimeisimmät",
+      en: "Latest",
+    },
+    upcoming: {
+      fi: "Lähitulevaisuus",
+      en: "Upcoming",
+    },
   },
   columns: {
     bookingNumber: {
@@ -69,6 +81,10 @@ export const bookingList = {
     bookingDate: {
       fi: "Tilauspäivä",
       en: "Booking Date",
+    },
+    startDate: {
+      fi: "Aloituspäivä",
+      en: "Start Date",
     },
   },
   buttons: {

--- a/frontend/src/types/booking.ts
+++ b/frontend/src/types/booking.ts
@@ -3,6 +3,7 @@ import { BaseEntity, ErrorContext, Translatable } from "./common";
 import { ItemTranslation } from "./item";
 import { Database } from "@common/supabase.types";
 import { StripNull } from "@common/helper.types";
+import { BookingPreviewWithOrgData } from "@common/bookings/booking.types";
 
 /**
  * Booking status values
@@ -29,8 +30,8 @@ export interface BookingType extends BaseEntity {
  * Booking state in Redux store
  */
 export interface BookingsState {
-  bookings: BookingPreview[];
-  userBookings: BookingPreview[];
+  bookings: BookingPreviewWithOrgData[]; // Admin bookings with org-specific data
+  userBookings: BookingPreview[]; // User bookings without org-specific data
   loading: boolean;
   error: string | null;
   errorContext: ErrorContext;
@@ -90,7 +91,8 @@ export type ValidBookingOrder =
   | "created_at"
   | "booking_number"
   | "status"
-  | "full_name";
+  | "full_name"
+  | "start_date";
 
 export type BookingUserView =
   Database["public"]["Views"]["view_bookings_with_user_info"];


### PR DESCRIPTION
This pull request introduces significant improvements to the organization-specific booking listing and ordering features in the admin dashboard. The backend logic for fetching bookings has been refactored to provide organization-specific status and support ordering by booking start date. The frontend now allows toggling between recent and upcoming bookings, displays organization-specific status and start dates, and includes additional status filters and translations.

**Backend logic and API improvements:**

* Refactored the `BookingService.getOrderedBookingsForOrg` method to calculate and attach organization-specific status and start date for each booking, apply filtering and sorting based on these fields, and handle pagination entirely in memory for organization-relevant bookings.
* Updated the booking types to include the new `BookingPreviewWithOrgData` type, which extends `BookingPreview` with `org_status_for_active_org` and `start_date` fields for frontend use.
* Added support for ordering bookings by `start_date` in both backend and type definitions. [[1]](diffhunk://#diff-26e01dcc63170f3fcb80803589d008ea924ac193d69637fe08cbd2efb6c3bcbdL77-R78) [[2]](diffhunk://#diff-a5c833eb9f799c8932898f025580d5d44053f9c8bb829b6766b9c7364370c2afL93-R95)

**Frontend booking list and dashboard enhancements:**

* Updated the admin booking list to use the new extended booking type, display organization-specific status and start date, and allow toggling between ordering by recent (`created_at`) and upcoming (`start_date`) bookings. [[1]](diffhunk://#diff-b173147ad49fab9d0d0a34ab4ac2e063b37f71e0fe7460ed6f7de03dfe10d142L68-R81) [[2]](diffhunk://#diff-b173147ad49fab9d0d0a34ab4ac2e063b37f71e0fe7460ed6f7de03dfe10d142R118-R135) [[3]](diffhunk://#diff-b173147ad49fab9d0d0a34ab4ac2e063b37f71e0fe7460ed6f7de03dfe10d142R243-R277)
* Added new status filter options ("picked_up", "returned", "completed") and improved translation support for these and other booking list filters. [[1]](diffhunk://#diff-b173147ad49fab9d0d0a34ab4ac2e063b37f71e0fe7460ed6f7de03dfe10d142R220-R228) [[2]](diffhunk://#diff-2d6e815656006cf8013018f189d03e5c3c57e3314d2070649bfb00bfc5a4c5d3R42-R66) [[3]](diffhunk://#diff-2d6e815656006cf8013018f189d03e5c3c57e3314d2070649bfb00bfc5a4c5d3R85-R88)

**Type and state management updates:**

* Updated Redux state and type definitions to use the new extended booking type for admin bookings, ensuring organization-specific data is available throughout the frontend. [[1]](diffhunk://#diff-a5c833eb9f799c8932898f025580d5d44053f9c8bb829b6766b9c7364370c2afL32-R34) [[2]](diffhunk://#diff-a5c833eb9f799c8932898f025580d5d44053f9c8bb829b6766b9c7364370c2afR6)

These changes collectively provide a more accurate and flexible booking overview for organization admins, supporting better filtering, sorting, and display of relevant booking data.