### PR TITLE
Con2 275.1 block less than day booking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,32 +4,39 @@ import { UserProfileLoader } from "./context/UserProfileLoader";
 import Footer from "./components/Footer";
 import { Outlet } from "react-router-dom";
 import { AuthProvider } from "./context/AuthProvider";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
 
 function App() {
   return (
     <AuthProvider>
-      <div className="min-h-screen flex flex-col text-primary">
-        <UserProfileLoader />
-        <Navigation />
-        <main className="flex-1">
-          <Outlet />
-        </main>
-        <Footer />
-        <Toaster
-          position="top-right"
-          duration={3000}
-          richColors
-          offset={{ top: 100 }}
-          mobileOffset={{ top: 100 }}
-          closeButton
-          toastOptions={{
-            classNames: {
-              closeButton: "toast-close",
-              toast: "custom-toast",
-            },
-          }}
-        />
-      </div>
+      <TooltipProvider
+        delayDuration={200}
+        skipDelayDuration={200}
+        disableHoverableContent
+      >
+        <div className="min-h-screen flex flex-col text-primary">
+          <UserProfileLoader />
+          <Navigation />
+          <main className="flex-1">
+            <Outlet />
+          </main>
+          <Footer />
+          <Toaster
+            position="top-right"
+            duration={3000}
+            richColors
+            offset={{ top: 100 }}
+            mobileOffset={{ top: 100 }}
+            closeButton
+            toastOptions={{
+              classNames: {
+                closeButton: "toast-close",
+                toast: "custom-toast",
+              },
+            }}
+          />
+        </div>
+      </TooltipProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 function App() {
   return (
     <AuthProvider>
+      {/* Added TooltipProvider to App so we only have one provider for tooltips */}
       <TooltipProvider
         delayDuration={200}
         skipDelayDuration={200}

--- a/frontend/src/components/Items/ItemCard.tsx
+++ b/frontend/src/components/Items/ItemCard.tsx
@@ -2,7 +2,6 @@ import imagePlaceholder from "@/assets/defaultImage.jpg";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useLanguage } from "@/context/LanguageContext";
@@ -379,41 +378,39 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item }) => {
         </div>
 
         {/* Add to Cart Button with Tooltip */}
-        <TooltipProvider>
-          <Tooltip open={isAddToCartDisabled ? undefined : false}>
-            <TooltipTrigger asChild>
-              <span
-                tabIndex={0}
-                className={
-                  isAddToCartDisabled
-                    ? "inline-block w-full cursor-not-allowed"
-                    : "inline-block w-full"
-                }
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              tabIndex={0}
+              className={
+                isAddToCartDisabled
+                  ? "inline-block w-full cursor-not-allowed"
+                  : "inline-block w-full"
+              }
+            >
+              <Button
+                onClick={handleAddToCart}
+                className="w-full bg-background rounded-2xl text-secondary border-secondary border-1 hover:text-white hover:bg-secondary"
+                disabled={isAddToCartDisabled}
+                style={{
+                  pointerEvents: isAddToCartDisabled ? "none" : "auto",
+                }}
+                data-cy="item-add-to-cart-btn"
               >
-                <Button
-                  onClick={handleAddToCart}
-                  className="w-full bg-background rounded-2xl text-secondary border-secondary border-1 hover:text-white hover:bg-secondary"
-                  disabled={isAddToCartDisabled}
-                  style={{
-                    pointerEvents: isAddToCartDisabled ? "none" : "auto",
-                  }}
-                  data-cy="item-add-to-cart-btn"
-                >
-                  {t.itemDetails.items.addToCart[lang]}
-                </Button>
-              </span>
-            </TooltipTrigger>
-            {isAddToCartDisabled && (
-              <TooltipContent>
-                {!startDate || !endDate ? (
-                  <p>{t.itemCard.selectDatesFirst[lang]}</p>
-                ) : (
-                  <p>{t.itemCard.selectValidQuantity[lang]} </p>
-                )}
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </TooltipProvider>
+                {t.itemDetails.items.addToCart[lang]}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {isAddToCartDisabled && (
+            <TooltipContent>
+              {!startDate || !endDate ? (
+                <p>{t.itemCard.selectDatesFirst[lang]}</p>
+              ) : (
+                <p>{t.itemCard.selectValidQuantity[lang]} </p>
+              )}
+            </TooltipContent>
+          )}
+        </Tooltip>
       </div>
 
       {/* View Details Button */}

--- a/frontend/src/components/TimeframeSelector.tsx
+++ b/frontend/src/components/TimeframeSelector.tsx
@@ -97,6 +97,7 @@ const TimeframeSelector: React.FC = () => {
         setConfirmClearDates(true);
         toast.warning(t.timeframeSelector.toast.warning[lang], {
           id: "timeframe-toast",
+          duration: 4500,
         });
         // auto-reset the confirm flag after a short window to avoid accidental clears later
         window.setTimeout(() => setConfirmClearDates(false), 4000);
@@ -217,14 +218,19 @@ const TimeframeSelector: React.FC = () => {
         </div>
 
         <div className="flex w-full lg:w-auto items-center justify-center">
+          {/* Clear Dates Button */}
           <Button
             size="sm"
             onClick={handleClearTimeframe}
-            className={`mt-6 bg-white text-highlight2 border border-highlight2 hover:bg-highlight2 hover:text-white ${
-              startDate || endDate ? "visible" : "invisible"
-            }`}
+            className={`mt-6 ${
+              confirmClearDates
+                ? "bg-amber-500 text-white hover:bg-amber-600"
+                : "bg-white text-highlight2 border border-highlight2 hover:bg-highlight2 hover:text-white"
+            } ${startDate || endDate ? "visible" : "invisible"}`}
           >
-            {t.timeframeSelector.clearDates[lang]}
+            {confirmClearDates
+              ? t.timeframeSelector.confirmClear[lang]
+              : t.timeframeSelector.clearDates[lang]}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/TimeframeSelector.tsx
+++ b/frontend/src/components/TimeframeSelector.tsx
@@ -5,7 +5,7 @@ import { Calendar } from "./ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import DatePickerButton from "./ui/DatePickerButton";
 import { Button } from "./ui/button";
-import { selectCartItems } from "../store/slices/cartSlice";
+import { selectCartItems, clearCart } from "../store/slices/cartSlice";
 import { toast } from "sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { Info } from "lucide-react";
@@ -28,6 +28,8 @@ const TimeframeSelector: React.FC = () => {
   const { lang } = useLanguage();
   const { formatDate } = useFormattedDate();
 
+  const [confirmClearDates, setConfirmClearDates] = React.useState(false);
+
   const handleDateChange = (type: "start" | "end", date: Date | undefined) => {
     if (cartItems.length > 0) {
       toast.warning(t.timeframeSelector.toast.warning[lang]);
@@ -42,12 +44,13 @@ const TimeframeSelector: React.FC = () => {
         const diffTime = newEndDate.getTime() - newStartDate.getTime();
         const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
+        // These only fire when the user changes start date after both dates are set
         if (diffDays < 1) {
-          toast.error("Booking must be at least 1 day long");
+          toast.error(t.timeframeSelector.toast.errorSameDay[lang]);
           return;
         }
         if (diffDays > 42) {
-          toast.error("Booking cannot exceed 6 weeks");
+          toast.error(t.timeframeSelector.toast.errorTooLong[lang]);
           return;
         }
       }
@@ -63,6 +66,17 @@ const TimeframeSelector: React.FC = () => {
         endDatePopoverRef.current?.click(); // trigger popover
       }, 150);
     } else {
+      // Guard: end date must be strictly after start date
+      if (date && startDateStr) {
+        const start = new Date(startDateStr);
+        const startDay = new Date(start.setHours(0, 0, 0, 0)).getTime();
+        const endDay = new Date(date.setHours(0, 0, 0, 0)).getTime();
+        if (endDay <= startDay) {
+          toast.error(t.timeframeSelector.toast.errorEndBeforeStart[lang]);
+          return;
+        }
+      }
+
       dispatch(
         setTimeframe({
           startDate: startDateStr,
@@ -77,10 +91,26 @@ const TimeframeSelector: React.FC = () => {
   };
 
   const handleClearTimeframe = () => {
+    // If there are items in the cart, require a confirming second click
     if (cartItems.length > 0) {
-      toast.warning(t.timeframeSelector.toast.warning[lang]);
+      if (!confirmClearDates) {
+        setConfirmClearDates(true);
+        toast.warning(t.timeframeSelector.toast.warning[lang], {
+          id: "timeframe-toast",
+        });
+        // auto-reset the confirm flag after a short window to avoid accidental clears later
+        window.setTimeout(() => setConfirmClearDates(false), 4000);
+        return;
+      }
+      // Second click within the window: clear cart and timeframe
+      dispatch(clearCart());
+      dispatch(clearTimeframe());
+      setConfirmClearDates(false);
+      toast.success(t.cart.toast.cartCleared[lang], { id: "timeframe-toast" });
       return;
     }
+
+    // No items in cart – just clear dates
     dispatch(clearTimeframe());
   };
 
@@ -159,11 +189,15 @@ const TimeframeSelector: React.FC = () => {
                   defaultMonth={startDate} // Problem: Currently does not let user change month
                   disabled={(date) => {
                     // Always return a boolean value:
-                    const isBeforeToday =
-                      date < new Date(new Date().setHours(0, 0, 0, 0));
-                    const isBeforeStartDate = startDate
-                      ? date < startDate
+                    const todayMidnight = new Date(
+                      new Date().setHours(0, 0, 0, 0),
+                    );
+                    const isBeforeToday = date < todayMidnight;
+
+                    const isBeforeOrSameAsStartDate = startDate
+                      ? date <= new Date(startDate.setHours(0, 0, 0, 0))
                       : false;
+
                     // prevent dates more than 42 days from start
                     const isTooFarFromStart = startDate
                       ? date.getTime() >
@@ -171,7 +205,9 @@ const TimeframeSelector: React.FC = () => {
                       : false;
 
                     return (
-                      isBeforeToday || isBeforeStartDate || isTooFarFromStart
+                      isBeforeToday ||
+                      isBeforeOrSameAsStartDate ||
+                      isTooFarFromStart
                     );
                   }}
                 />

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -113,11 +113,13 @@ function SidebarProvider({
     <SidebarContext.Provider value={contextValue}>
       <div
         data-slot="sidebar-wrapper"
-        style={{
-          "--sidebar-width": SIDEBAR_WIDTH,
-          "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-          ...style,
-        } as React.CSSProperties}
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
         className={cn(
           "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
           className,

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -21,7 +21,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
@@ -112,25 +111,21 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
-        <div
-          data-slot="sidebar-wrapper"
-          style={
-            {
-              "--sidebar-width": SIDEBAR_WIDTH,
-              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-              ...style,
-            } as React.CSSProperties
-          }
-          className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
-            className,
-          )}
-          {...props}
-        >
-          {children}
-        </div>
-      </TooltipProvider>
+      <div
+        data-slot="sidebar-wrapper"
+        style={{
+          "--sidebar-width": SIDEBAR_WIDTH,
+          "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+          ...style,
+        } as React.CSSProperties}
+        className={cn(
+          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
     </SidebarContext.Provider>
   );
 }

--- a/frontend/src/translations/modules/timeframeSelector.ts
+++ b/frontend/src/translations/modules/timeframeSelector.ts
@@ -36,5 +36,17 @@ export const timeframeSelector = {
       fi: "Päivämäärien muuttaminen tyhjentää ostoskorisi. Viimeistele tai tyhjennä nykyinen varauksesi ensin.",
       en: "Changing dates will clear your cart. Please complete or clear your current booking first.",
     },
+    errorSameDay: {
+      fi: "Varausajan on oltava vähintään 1 päivän mittainen",
+      en: "Booking must be at least 1 day long",
+    },
+    errorTooLong: {
+      fi: "Varaus ei voi ylittää 6 viikkoa",
+      en: "Booking cannot exceed 6 weeks",
+    },
+    errorEndBeforeStart: {
+      fi: "Loppupäivän on oltava alkupäivän jälkeen",
+      en: "End date must be after start date",
+    },
   },
 };

--- a/frontend/src/translations/modules/timeframeSelector.ts
+++ b/frontend/src/translations/modules/timeframeSelector.ts
@@ -31,6 +31,10 @@ export const timeframeSelector = {
     fi: "Tyhjennä päivämäärät",
     en: "Clear Dates",
   },
+  confirmClear: {
+    fi: "Vahvista tyhjennys",
+    en: "Click again to clear cart & dates",
+  },
   toast: {
     warning: {
       fi: "Päivämäärien muuttaminen tyhjentää ostoskorisi. Viimeistele tai tyhjennä nykyinen varauksesi ensin.",


### PR DESCRIPTION
In this PR I mostly focused on the Storage page through the **TimeframeSelector.tsx** I tried to get rid of any warnings in the console and helped make the UI a bit more user friendly.

## Time Selector

- The toasts arent firing unless you select the first date, then select the second date, then make select the first date again the wrong way.
- Instead of relying on toasts I just disabled the day after the start date so its not possible to do.
- Updated the clear cart button to actually clear the cart like it says in the toast message when you click another time in 4 seconds.
- Added translations to all strings in the file.

## App.tsx

- Added **ToolTipProvider** and removed it from everywhere else in the app to get rid of the yellow warnings we were getting on the Storage tab.
