### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -318,22 +318,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // 7. For Google OAuth specifically, clear any Google session cookies
       // This helps ensure the next login shows the account picker
-      if (document.cookie.includes("accounts.google.com")) {
-        // Note: This is a best-effort approach for Google session clearing
-        document.cookie.split(";").forEach((c) => {
-          const eqPos = c.indexOf("=");
-          const name = eqPos > -1 ? c.substr(0, eqPos).trim() : c.trim();
-          if (
-            name.includes("google") ||
-            name.includes("oauth") ||
-            name.includes("_ga")
-          ) {
-            document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.google.com`;
-            document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.accounts.google.com`;
-            document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
-          }
-        });
-      }
+      // Note: This is a best-effort approach for Google session clearing
+      // Clear cookies whose names match known Google OAuth session cookie patterns
+      const googleCookieNames = [
+        "G_AUTHUSER",      // Google auth user session
+        "GAPS",            // Google account session
+        "LSID",            // Google session ID
+        "Oauth_Token",     // Google OAuth token
+        "_ga",             // Google Analytics
+        // Add any other cookie names as needed
+      ];
+      document.cookie.split(";").forEach((c) => {
+        const eqPos = c.indexOf("=");
+        const name = eqPos > -1 ? c.substr(0, eqPos).trim() : c.trim();
+        if (
+          googleCookieNames.some((cookieName) => name.startsWith(cookieName)) ||
+          name.toLowerCase().includes("google") ||
+          name.toLowerCase().includes("oauth")
+        ) {
+          document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.google.com`;
+          document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;domain=.accounts.google.com`;
+          document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        }
+      });
     } catch {
       clearCachedAuthToken();
       // Even if there's an error, still clear local data and navigate


### PR DESCRIPTION
Potential fix for [https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/8](https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/8)

The problem is the substring check for "accounts.google.com" on the entire `document.cookie` string, which cannot reliably determine if a Google session cookie is present. To fix this, the code should iterate over existing cookies and only attempt to clear cookies whose names match known Google OAuth session-related patterns (e.g., prefix "G_AUTHUSER", "_ga", "OAuth_", etc.), or that are set specifically for `.accounts.google.com` domain if possible. Since JavaScript running client-side can't access cookies for other domains due to the same-origin policy, the clearing action here is mostly a "cleanup attempt"—but matching by exact cookie name/prefix is safer and avoids false positives/errors.

Edit only the check at line 321 and the cookie-clearing loop to:
- Remove the substring check,
- Instead, always perform the cookie deletion for known Google OAuth-related cookie names,
- Optionally, maintain the current loop to maximize the cleanup effect, but only for cookie names that match well-known patterns.

No external library is needed, only standard JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
