### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment-front.yml
+++ b/.github/workflows/deployment-front.yml
@@ -1,4 +1,7 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/13](https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/13)

To fix the problem, we should explicitly declare a `permissions` block at the top level of the workflow (so it applies to all jobs unless overridden), granting only the minimum required permissions necessary for this workflow to function. 

For most static web app deployments and CI/CD processes, the minimal starting point is:

```yaml
permissions:
  contents: read
```

However, since the `build_and_deploy_job` provides a `repo_token: ${{ secrets.GITHUB_TOKEN }}` to `Azure/static-web-apps-deploy@v1`, and this action uses the token for status checks and PR comments (as noted in the inline comment at line 77), the workflow should also grant `pull-requests: write` for PR automation to work.

Therefore, right after the `name: ...` entry and before the `on: ...` block, add the following:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No other lines or blocks need to be modified. This change will restrict the default token as recommended, and if in the future you wish to further restrict for each job, you can override at the job level. No new methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
