### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment-front.yml
+++ b/.github/workflows/deployment-front.yml
@@ -1,4 +1,7 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/12](https://github.com/con2/Harakka-Storage-Solutions/security/code-scanning/12)

To fix this problem, explicitly add a `permissions` block at the top of the workflow file, setting the minimal permissions necessary for the jobs.  
For this workflow, the minimal required permissions are `contents: read` (for actions such as checkout) and `pull-requests: write` (for deployment jobs that might comment on pull requests via the `repo_token`).  
Add the following under the `name:` line, before the `on:` block, so it is inherited by all jobs unless overridden  
No new methods, imports, nor definitions are necessary; this is a straightforward addition to the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
