### PR TITLE
Con2 329 cart checkout fails items are out of stock 

### DIFF
--- a/backend/src/modules/booking/booking.service.ts
+++ b/backend/src/modules/booking/booking.service.ts
@@ -600,35 +600,16 @@ export class BookingService {
       }
 
       // 3.1. Check availability for requested date range
-      const available = await calculateAvailableQuantity(
+      const { availableQuantity } = await calculateAvailableQuantity(
         supabase,
         item_id,
         start_date,
         end_date,
       );
 
-      if (quantity > available.availableQuantity) {
+      if (quantity > availableQuantity) {
         throw new BadRequestException(
-          `Not enough virtual stock available for item ${item_id}`,
-        );
-      }
-
-      // 3.2. Check physical stock (currently in storage)
-      const { data: storageItem, error: itemError } = await supabase
-        .from("storage_items")
-        .select("available_quantity")
-        .eq("id", item_id)
-        .single();
-
-      if (itemError) handleSupabaseError(itemError);
-
-      if (!storageItem)
-        throw new BadRequestException("Storage item data not found");
-
-      const currentStock = storageItem.available_quantity ?? 0;
-      if (quantity > currentStock) {
-        throw new BadRequestException(
-          `Not enough physical stock in storage for item ${item_id}`,
+          `Requested quantity exceeds available quantity for item: ${item_id}. Requested ${quantity} but there is only ${availableQuantity} available.`,
         );
       }
     }

--- a/backend/src/modules/booking/dto/create-booking.dto.ts
+++ b/backend/src/modules/booking/dto/create-booking.dto.ts
@@ -62,6 +62,14 @@ class BookingItemDto {
   )
   @Validate(StartBeforeEndConstraint)
   end_date!: string;
+
+  @IsString()
+  @IsUUID()
+  provider_organization_id: string;
+
+  @IsString()
+  @IsUUID()
+  location_id: string;
 }
 
 export class CreateBookingDto {

--- a/backend/src/modules/booking_items/booking-items.controller.ts
+++ b/backend/src/modules/booking_items/booking-items.controller.ts
@@ -91,10 +91,10 @@ export class BookingItemsController {
   })
   async createBookingItem(
     @Req() req: AuthRequest,
-    @Body() booking_item: BookingItemsInsert,
+    @Body() booking_item: BookingItemsInsert | BookingItemsInsert[],
   ) {
     const supabase = req.supabase;
-    return await this.bookingItemsService.createBookingItem(
+    return await this.bookingItemsService.createBookingItems(
       supabase,
       booking_item,
     );

--- a/backend/src/modules/booking_items/booking-items.service.ts
+++ b/backend/src/modules/booking_items/booking-items.service.ts
@@ -9,10 +9,7 @@ import {
   BookingItemsRow,
   BookingItemsUpdate,
 } from "./interfaces/booking-items.interfaces";
-import {
-  ApiResponse,
-  ApiSingleResponse,
-} from "../../../../common/response.types";
+import { ApiResponse, ApiSingleResponse } from "@common/response.types";
 import { getPaginationMeta, getPaginationRange } from "src/utils/pagination";
 import { StorageItemRow } from "../storage-items/interfaces/storage-item.interface";
 
@@ -114,16 +111,15 @@ export class BookingItemsService {
     return { ...result, metadata };
   }
 
-  async createBookingItem(
+  async createBookingItems(
     supabase: SupabaseClient,
-    booking_item: BookingItemsInsert,
-  ): Promise<ApiSingleResponse<BookingItemsRow>> {
-    const result: PostgrestSingleResponse<BookingItemsRow> = await supabase
-      .from("booking_items")
-      .insert(booking_item)
-      .select()
-      .single();
-
+    booking_items: BookingItemsInsert | BookingItemsInsert[],
+  ): Promise<
+    ApiResponse<BookingItemsRow> | ApiSingleResponse<BookingItemsRow>
+  > {
+    const query = supabase.from("booking_items").insert(booking_items).select();
+    if (!Array.isArray(booking_items)) query.single();
+    const result = await query;
     if (result.error)
       throw new BadRequestException("Could not create booking-item");
 

--- a/frontend/src/components/MyBookings.tsx
+++ b/frontend/src/components/MyBookings.tsx
@@ -401,7 +401,6 @@ const MyBookings = () => {
             o.org_booking_status !== "completed" &&
             o.locations.some((l) => l.pickup_status === "picked_up"),
         );
-        console.log(orgs_with_picked_up_items);
         return (
           <div className="flex space-x-2">
             <BookingDetailsButton

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -184,13 +184,25 @@ const Cart: React.FC = () => {
     }
 
     // Format booking data according to backend expectations
-    const bookingData = {
+    const bookingData: {
+      user_id: string;
+      items: {
+        start_date: string;
+        end_date: string;
+        item_id: string;
+        quantity: number;
+        location_id: string;
+        provider_organization_id: string;
+      }[];
+    } = {
       user_id: userProfile.id,
       items: cartItems.map((item) => ({
         item_id: item.item.id,
         quantity: item.quantity,
         start_date: startDate.toISOString(),
         end_date: endDate.toISOString(),
+        location_id: item.item.location_id,
+        provider_organization_id: item.item.org_id ?? item.item.organization_id,
       })),
     };
 

--- a/frontend/src/types/booking.ts
+++ b/frontend/src/types/booking.ts
@@ -61,6 +61,8 @@ export interface CreateBookingDto {
     quantity: number;
     start_date: string;
     end_date: string;
+    location_id: string;
+    provider_organization_id: string;
   }[];
 }
 

--- a/frontend/src/types/item.ts
+++ b/frontend/src/types/item.ts
@@ -57,6 +57,8 @@ interface ItemAugmentedFields {
  */
 export type Item = Override<StorageItemRow, ItemAugmentedFields> & {
   location_details: StorageLocationRow;
+  organization_id?: string;
+  org_id?: string;
 };
 
 /**


### PR DESCRIPTION
## Fix Cart checkout fail because of "stock"
## Add rollback system to creating a booking

The reason createBooking would sometimes fail was because we checked availability twice in two different places. Since we should only have **_one source of truth_** I removed the secondary check (which checked available_quantity in storage_items).

I also did a small refactor in `createBookingItems` to allow several items to be inserted at the same time, instead of having to loop them, so we call the db less.

And finally I added a rollback system when creating a booking, so _if_ a booking was to fail, it would remove any (partially) inserted data. I personally tested this by throwing an error when inserting booking_items for example. I decided to allow bookings to be created even if the email sending fails, since the user can still see the booking in the app.

