### PR TITLE
fix duplicate primary key issue; add confirm when deleting a category

### DIFF
--- a/frontend/src/components/Admin/Categories/category.schema.ts
+++ b/frontend/src/components/Admin/Categories/category.schema.ts
@@ -1,13 +1,13 @@
 import z from "zod";
 
-export const initialData = {
-  id: crypto.randomUUID() as string,
+export const getInitialData = () => ({
+  id: crypto.randomUUID(),
   translations: {
     fi: "",
     en: "",
   },
   parent_id: null,
-};
+});
 
 export const createCategoryDto = z.object({
   id: z.string().uuid(),

--- a/frontend/src/pages/AdminPanel/Categories.tsx
+++ b/frontend/src/pages/AdminPanel/Categories.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { t } from "@/translations";
+import { toastConfirm } from "@/components/ui/toastConfirm";
 
 function Categories() {
   const { lang } = useLanguage();
@@ -98,6 +99,7 @@ function Categories() {
       ),
       cell: ({ row }) => {
         const { id } = row.original;
+        const category_name = row.original.translations[lang];
         return (
           <div className="text-right">
             <Button
@@ -106,7 +108,15 @@ function Categories() {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                void handleDelete(id);
+                toastConfirm({
+                  title: t.categories.messages.delete.title[lang].replace(
+                    "{category_name}",
+                    category_name,
+                  ),
+                  confirmText: t.categories.messages.delete.confirmText[lang],
+                  cancelText: t.categories.messages.delete.cancelText[lang],
+                  onConfirm: () => handleDelete(id) as Promise<void>,
+                });
               }}
             >
               <Trash />

--- a/frontend/src/translations/modules/addCategory.ts
+++ b/frontend/src/translations/modules/addCategory.ts
@@ -48,6 +48,10 @@ export const addCategory = {
       fi: "Jotain meni pieleen. Yritä uudelleen myöhemmin tai ota yhteyttä tukeen.",
       en: "Something went wrong. Try again later or contact support",
     },
+    loading: {
+      en: "Loading...",
+      fi: "Ladataan...",
+    },
   },
   buttons: {
     cancel: {

--- a/frontend/src/translations/modules/categories.ts
+++ b/frontend/src/translations/modules/categories.ts
@@ -35,6 +35,18 @@ export const categories = {
         fi: "Kategoria poistettiin",
         en: "Category was deleted",
       },
+      title: {
+        en: "Are you sure you want to delete {category_name} as a category?",
+        fi: "Haluatko varmasti poistaa kategorian {category_name}?",
+      },
+      confirmText: {
+        en: "Yes",
+        fi: "Kyllä",
+      },
+      cancelText: {
+        en: "Cancel",
+        fi: "Peruuta",
+      },
     },
   },
   buttons: {


### PR DESCRIPTION
**The issue:**
Adding two categories would fail because the second category still had the same ID as the first one, causing a "duplicate primary key" issue in the DB.

**The fix:**
The initial data of the category form is now a function instead of an object, so anytime it is called there is a new ID

**Extra:**
I also added a confirmation when deleting a category, so that it's not so easy to mistakenly delete a category by misclicking